### PR TITLE
Issue #152 codex warning split

### DIFF
--- a/src/components/codex/CodexEntry.tsx
+++ b/src/components/codex/CodexEntry.tsx
@@ -2,7 +2,14 @@ import Title from "antd/es/typography/Title";
 import Link from "next/link";
 
 export default function CodexEntry(
-    {slug, title, date, description, category, contentWarning, staffPick, duration, level=2}: {slug:string, title:string, date:string, description:string, category:string, contentWarning:string, staffPick:string, duration:number, level?:2 | 1 | 5 | 3 | 4 | undefined}) {
+  { slug, title, date, description, category, contentWarning, staffPick, duration, level = 2 }: { slug: string, title: string, date: string, description: string, category: string, contentWarning: string | string[], staffPick: string, duration: number, level?: 2 | 1 | 5 | 3 | 4 | undefined }) {
+
+  const warningsList = Array.isArray(contentWarning)
+    ? contentWarning.map(w => String(w).trim()).sort()
+    : typeof contentWarning === "string"
+      ? contentWarning.split(",").map(w => w.trim()).sort()
+      : [];
+
   return (
     <li key={slug} className="mb-8">
       <Link
@@ -13,11 +20,11 @@ export default function CodexEntry(
       </Link>
       <p>{description}</p>
       <div className="mt-2">
-        {contentWarning && (
-          <span className="bg-[#30011a] text-sm px-2 py-1 rounded mr-2">
-            ⚠️ {contentWarning}
+        {warningsList.map((warning, index) => (
+          <span key={warning} className="bg-[#30011a] text-sm px-2 py-1 rounded mr-2 inline-block mb-2">
+            {index === 0 && "⚠️ "} {warning}
           </span>
-        )}
+        ))}
         {staffPick == "True" && (
           <span className="bg-[#013011] text-sm px-2 py-1 rounded mr-2">
             ❤️ Staff Favourite

--- a/src/components/codex/CodexEntry.tsx
+++ b/src/components/codex/CodexEntry.tsx
@@ -4,11 +4,14 @@ import Link from "next/link";
 export default function CodexEntry(
   { slug, title, date, description, category, contentWarning, staffPick, duration, level = 2 }: { slug: string, title: string, date: string, description: string, category: string, contentWarning: string | string[], staffPick: string, duration: number, level?: 2 | 1 | 5 | 3 | 4 | undefined }) {
 
-  const warningsList = Array.isArray(contentWarning)
-    ? contentWarning.map(w => String(w).trim()).sort()
-    : typeof contentWarning === "string"
-      ? contentWarning.split(",").map(w => w.trim()).sort()
-      : [];
+  const rawArray = Array.isArray(contentWarning)
+    ? contentWarning
+    : String(contentWarning || "").split(",");
+
+  const warningsList = rawArray
+    .map(w => String(w).trim())
+    .filter(Boolean)
+    .sort();
 
   return (
     <li key={slug} className="mb-8">

--- a/src/components/codex/CodexList.tsx
+++ b/src/components/codex/CodexList.tsx
@@ -22,8 +22,8 @@ export default function CodexList({ posts }: { posts: any[] }) {
         <Divider />
         <ul>
           {posts.map(
-            ({ slug, title, date, description, category, contentWarning, staffPick, duration }) => (
-              <CodexEntry key={slug} slug={slug} title={title} date={date} description={description} category={category} contentWarning={contentWarning} staffPick={staffPick} duration={duration}></CodexEntry>
+            ({ slug, title, date, description, category, contentWarnings, staffPick, duration }) => (
+              <CodexEntry key={slug} slug={slug} title={title} date={date} description={description} category={category} contentWarning={contentWarnings} staffPick={staffPick} duration={duration}></CodexEntry>
             )
           )}
         </ul>

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -17,6 +17,15 @@ function isValidMarkdown(filename: string) {
   return filename.endsWith('.md') && filename !== '_DEV.md';
 }
 
+function parseContentWarnings(warningStr?: string): string[] {
+  if (!warningStr) return [];
+  return warningStr
+    .split(',')
+    .map(w => w.trim())
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b));
+}
+
 export function getSortedPosts() {
   const filenames = fs
     .readdirSync(postsDirectory)
@@ -27,16 +36,20 @@ export function getSortedPosts() {
     const fullPath = path.join(postsDirectory, filename);
     const fileContents = fs.readFileSync(fullPath, 'utf8');
     const { data } = matter(fileContents);
+    const meta = data as PostMeta;
 
     return {
       slug,
-      ...(data as PostMeta),
+      contentWarnings: parseContentWarnings(meta.contentWarning),
+      ...meta,
     };
   });
 
   // Sort by date descending (most recent first)
   return posts.sort((a, b) => (a.date < b.date ? 1 : -1));
 }
+
+
 
 export function getAllSlugs() {
   const filenames = fs
@@ -53,12 +66,13 @@ export async function getPostBySlug(slug: string) {
   const fileContents = fs.readFileSync(fullPath, 'utf8');
 
   const { data, content } = matter(fileContents);
-  const contentMarkdown = content;
+  const meta = data as PostMeta;
 
   return {
     slug,
-    contentMarkdown,
-    ...(data as PostMeta),
+    contentMarkdown: content,
+    contentWarnings: parseContentWarnings(meta.contentWarning), // Attach parsed array
+    ...meta,
   };
 }
 


### PR DESCRIPTION
Fix content warning badge display logic
* Handled string vs array input for `contentWarning` to fix type errors
* Trimmed and alphabetized warning tags
* Split single warning string into individual badge UI elements
* Restricted the ⚠️ icon to only render on the first badge (this way looks better, I can revert it if its requested)